### PR TITLE
Potential fix for code scanning alert no. 20: DOM text reinterpreted as HTML

### DIFF
--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -131,8 +131,53 @@ document.addEventListener("DOMContentLoaded", function() {
     elements.forEach(element => {
         element.addEventListener("click", function(event) {
             event.preventDefault();
-            document.getElementById('lightbox').innerHTML = '<a id="close"></a><a id="next">&rsaquo;</a><a id="prev">&lsaquo;</a><div class="img" style="background: url(\''+this.getAttribute('href')+'\') center center / contain no-repeat;" title="'+this.getAttribute('title')+'" ><img src="'+this.getAttribute('href')+'" alt="'+this.getAttribute('title')+'" /></div><span>'+this.getAttribute('title')+'</span>';
-            document.getElementById('lightbox').style.display = 'block';
+            var lightbox = document.getElementById('lightbox');
+            // clear existing content
+            lightbox.textContent = '';
+
+            // close button
+            var closeLink = document.createElement('a');
+            closeLink.setAttribute('id', 'close');
+            lightbox.appendChild(closeLink);
+
+            // next button
+            var nextLink = document.createElement('a');
+            nextLink.setAttribute('id', 'next');
+            nextLink.innerHTML = '&rsaquo;';
+            lightbox.appendChild(nextLink);
+
+            // prev button
+            var prevLink = document.createElement('a');
+            prevLink.setAttribute('id', 'prev');
+            prevLink.innerHTML = '&lsaquo;';
+            lightbox.appendChild(prevLink);
+
+            var href = this.getAttribute('href');
+            var title = this.getAttribute('title') || '';
+
+            // image container
+            var imgContainer = document.createElement('div');
+            imgContainer.className = 'img';
+            imgContainer.setAttribute('title', title);
+            imgContainer.style.backgroundImage = "url('" + href + "')";
+            imgContainer.style.backgroundPosition = 'center center';
+            imgContainer.style.backgroundSize = 'contain';
+            imgContainer.style.backgroundRepeat = 'no-repeat';
+
+            // image element
+            var img = document.createElement('img');
+            img.setAttribute('src', href);
+            img.setAttribute('alt', title);
+            imgContainer.appendChild(img);
+
+            lightbox.appendChild(imgContainer);
+
+            // caption
+            var caption = document.createElement('span');
+            caption.textContent = title;
+            lightbox.appendChild(caption);
+
+            lightbox.style.display = 'block';
 
             setGallery(this);
         });


### PR DESCRIPTION
Potential fix for [https://github.com/wrenchpilot/floatingboy.org/security/code-scanning/20](https://github.com/wrenchpilot/floatingboy.org/security/code-scanning/20)

In general, to fix this problem you should avoid feeding unescaped DOM text into `innerHTML`. Either (a) build the DOM structure using `createElement`, `setAttribute`, and `textContent`, or (b) if using `innerHTML` is unavoidable, properly escape/encode any untrusted data before concatenating it into HTML. The safest, functionality-preserving approach here is to construct the lightbox content via DOM APIs rather than string concatenation, so that untrusted values are assigned as attributes and text, not parsed as HTML.

Concretely for `js/lightbox.js`, lines around 134 should be refactored. Instead of:

```js
document.getElementById('lightbox').innerHTML = '<a id="close"></a>...'+this.getAttribute('href')+'...'+this.getAttribute('title')+'...';
```

we can:  
1. Grab the `lightbox` element and clear it (`textContent = ''` or `innerHTML = ''`).  
2. Create the close/next/prev `<a>` elements with `document.createElement` and set their `id` and text content.  
3. Create the wrapping `<div class="img">` element, set its `className` and its `style.backgroundImage`/`backgroundPosition`/`backgroundSize`/`backgroundRepeat` instead of embedding a `style` string.  
4. Create the `<img>` element, set its `src` and `alt` using the `href` and `title` values.  
5. Create the `<span>` element and set its `textContent` to the title.  
6. Append all of these nodes into `lightbox` in the same structure as before.

This keeps behavior (appearance, event wiring, gallery logic) the same but eliminates the dangerous HTML concatenation and addresses all alert variants at this site.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
